### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,11 +1,8 @@
 name: Auto tag
-
 # Automatically push a tag every 1st and 15th of the month
-
 on:
   schedule:
     - cron: '0 13 15 * *'
-
 jobs:
   auto-tag:
     name: Automatic Tag
@@ -14,12 +11,11 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: '0'
-      
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.61.0
+        uses: anothrNick/github-tag-action@8c8163ef62cf9c4677c8e800f36270af27930f42 # 1.61.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,16 +10,14 @@
 # supported CodeQL languages.
 #
 name: "CodeQL"
-
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
   schedule:
     - cron: '23 20 * * 2'
-
 jobs:
   analyze:
     name: Analyze
@@ -28,43 +26,37 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ['go']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@72e89f03254b4b61b342456f8f1d4d761bece71d # v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@72e89f03254b4b61b342456f8f1d4d761bece71d # v2
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      #- run: |
+      #   make bootstrap
+      #   make release
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@72e89f03254b4b61b342456f8f1d4d761bece71d # v2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,15 +6,13 @@
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
 on: [pull_request]
-
 permissions:
   contents: read
-
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@e7aeea1772ec01da74cafda11c5caa463520ca59 # v3

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,14 +1,12 @@
 name: Release latest
-
 on:
   push:
     branches:
       - main
-
 jobs:
   # Push to latest
   container-push-latest:
-    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@bcf9ef7e1103629088515b26b202933b2e0c1399 # main
     with:
       name: audittail
       tag: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 name: Release
-
 on:
   push:
     tags:
       - v**
-
 jobs:
   auto-release:
     name: Create Release
@@ -13,18 +11,15 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         with:
           generate_release_notes: true
-
   container-main:
-    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@bcf9ef7e1103629088515b26b202933b2e0c1399 # main
     with:
       name: audittail
       tag: ${GITHUB_REF_NAME}
       dockerfile_path: images/audittail/Dockerfile
       platforms: linux/amd64,linux/arm64
-

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,4 @@
----
 name: security
-
 # Run for all pushes to main and pull requests when Go or YAML files change
 on:
   push:
@@ -8,20 +6,18 @@ on:
       - main
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
   schedule:
     - cron: '23 20 * * 2'
-
 jobs:
   scan-trivy:
     name: sec-scan-trivy
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 
-        uses: actions/checkout@v3
-      
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@1f6384b6ceecbbc6673526f865b818a2a06b07c9 # master
         with:
           scan-type: 'fs'
           security-checks: 'vuln,config,secret'
@@ -30,29 +26,25 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
           skip-dirs: 'tests'
-
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@72e89f03254b4b61b342456f8f1d4d761bece71d # v2
         with:
           sarif_file: 'trivy-results.sarif'
-
   scan-anchore:
     name: sec-scan-anchore
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 
-        uses: actions/checkout@v3
-      
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Scan current project
         id: codescan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3
         with:
           path: "."
           severity-cutoff: high
           acs-report-enable: true
-
       - name: upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@72e89f03254b4b61b342456f8f1d4d761bece71d # v2
         if: ${{ always() }}
         with:
           sarif_file: ${{ steps.codescan.outputs.sarif }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,115 +1,92 @@
----
 name: test
-
 # Run for all pushes to main and pull requests when Go or YAML files change
 on:
   push:
     branches:
       - main
   pull_request:
-
 jobs:
   test:
     name: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
           go-version: '1.19'
-
       - name: Run golangci-lint
         run: make lint
-
       - name: Run go tests and generate coverage report
         run: make coverage
-
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.out
           flags: unittests
           name: codecov-umbrella
-
   build-image:
     name: build-image
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 
-        uses: actions/checkout@v3
-
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./images/audittail/Dockerfile
           push: false
           tags: ghcr.io/metal-toolbox/audittail:latest
-
       - name: Scan image
         id: scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3
         with:
           image: ghcr.io/metal-toolbox/audittail:latest
           acs-report-enable: true
-
       - name: upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@72e89f03254b4b61b342456f8f1d4d761bece71d # v2
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      
       - name: Inspect action SARIF report
         run: cat ${{ steps.scan.outputs.sarif }}
-
   kube-test:
     strategy:
       matrix:
         scenario: [nonroot, rootuser]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 
-        uses: actions/checkout@v3
-
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.5.0
+        uses: helm/kind-action@17d9550df7d8b42739eaa81e137b09b3801c10cd # v1.5.0
         with:
           cluster_name: kind
-      
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: latest
-
       - name: Build image
         run: make image
-      
       - name: Load audittail image into kind cluster
         run: kind load docker-image ghcr.io/metal-toolbox/audittail:latest
-      
       - name: Create Namespace
         run: kubectl create namespace ${{ matrix.scenario }}
-      
       - name: Deploy test scenario
-        run: cd tests && helm dependency update ./kube_scenario/ && helm template kubescenario -s templates/${{ matrix.scenario }}.yml ./kube_scenario/ | kubectl apply -f - -n ${{ matrix.scenario }} 
-    
+        run: cd tests && helm dependency update ./kube_scenario/ && helm template kubescenario -s templates/${{ matrix.scenario }}.yml ./kube_scenario/ | kubectl apply -f - -n ${{ matrix.scenario }}
       - name: Wait for readiness
         run: kubectl wait --for=condition=ready --timeout=60s -n ${{ matrix.scenario }} pod myapp
-      
       - name: Get pod information
         run: kubectl describe -n ${{ matrix.scenario }} pod myapp
-      
       - name: Get logs
         id: logs
         run: |
           kubectl logs -n ${{ matrix.scenario }} myapp -c audit-logger
           echo "::set-output name=auditlog::$(kubectl logs -n ${{ matrix.scenario }} myapp -c audit-logger)"
-      
       - name: Inspect logs
         run: echo ${{ steps.logs.outputs.auditlog }}
-      
       - name: Check logs
         run: |
           echo ${{ steps.logs.outputs.auditlog }} | grep "This is an audit log"


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "53b246e90932c73cdd3400f7df29235685e2f601" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
